### PR TITLE
Polymer 1.0+

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -4,13 +4,11 @@
   "keywords": "lenses, polymer, web-components",
   "main": "lens-data-join.html",
   "dependencies": {  
-    "th-theme": "thelmanews/th-theme",
-    "polymer": "Polymer/polymer#~0.5.5",
-    "core-input": "Polymer/core-input#~0.5.5",
-    "core-component-page": "Polymer/core-component-page#~0.5.5"
+    "polymer": "Polymer/polymer#^1.0.0",
+    "iron-input": "PolymerElements/iron-input#~1.0.3"
   },
-  "dev-dependencies":  { 
-    "web-component-tester": "Polymer/web-component-tester#^2.2.6"
+  "devDependencies": {
+    "iron-component-page": "PolymerElements/iron-component-page#^1.0.0",
+    "web-component-tester": "*"
   }
 }
-

--- a/demo/index.html
+++ b/demo/index.html
@@ -62,61 +62,50 @@
 
   </head>
   <body unresolved>
-    <lens-data-join id="component"></lens-data-join>
 
-      <script>
-        var hi = [1, 2, 3, 4400];
-      </script>
+    <section>
+      <label>Input:</label>
+      <pre id="input"></pre>
+    </section>
+    <section class="component">
+      <label>Component:</label>
+      <lens-data-join id="component"></lens-data-join>
+    </section>
+    <section>
+      <label>Output:</label>
+      <pre id="output"></pre>
+    </section>
 
-    <template is="dom-bind">
+    <script>
 
+    // input data
+    var input = new Object([
+      {"index":1, "text":"Texas","dollar":"$139,000","text_number":"125 1ST ST","percent":"12.2%","date":"2-12-2015","date_unformat":"2-12-2015","billion":"1.2B"},
+      {"index":2, "text":"Vermont","dollar":"$15,300","text_number":"$126,000 Reward","percent":"0.6%","date":"2-12-2010","date_unformat":"12/25/1995","billion":".2B"},
+      {"index":3, "text":"New York","dollar":"$205,800","text_number":"2nd Place","percent":"1.5%","date":"5-12-2015","date_unformat":"February 20, 2015","billion":"1.2B"},
+      {"index":4, "text":"New Mexico","dollar":"$1,180,700","text_number":"only text","percent":"1.5%","date":"12-12-2012","date_unformat":"Jan 20, 2015","billion":"0.5B"},
+      {"index":5, "text":"California","dollar":"$188,400","text_number":"$ value","percent":"-0.4%","date":"1-1-2015","date_unformat":"3-3-2015","billion":"11B"},
+      {"index":6, "text":"Alaska","dollar":"$145,900","text_number":"Q3 2012","percent":"3.3%","date":"10-30-1915","date_unformat":"4/4/2015","billion":"9B"}
+      ]);
 
-        <template id="t" is="dom-repeat" items="{{hi}}">
-          <div> <span>{{item}}</span> <span>{{item}}</span></div>
-        </template>
+    window.onload = function() {
+      var elem = document.querySelector('#component');
+      var preInput = document.getElementById('input');
+      var preOutput = document.getElementById('output');
 
-    </template>
+      //set the input
+      elem.input = input;
 
-<!--       <section>
-        <label>Input:</label>
-        <template id="inputPre">
-          <pre id="input">{{component.input}}</pre>
-        </template>
-      </section>
-      <section class="component">
-        <label>Component:</label>
-      </section>
-      <section>
-        <label>Output:</label>
-        <pre id="output">{{myoutput}}</pre>
-      </section> -->
+      preInput.textContent = JSON.stringify(input, undefined, 2);
 
-      <script>
+      // update output
+      document.addEventListener('lens-output-changed', function(val) {
+        console.log(val);
+        preOutput.textContent = JSON.stringify(val.detail, undefined, 2);
+      });
+    };
 
-        // input data
-        var input = new Object([
-          {"index":1, "text":"Texas","dollar":"$139,000","text_number":"125 1ST ST","percent":"12.2%","date":"2-12-2015","date_unformat":"2-12-2015","billion":"1.2B"},
-          {"index":2, "text":"Vermont","dollar":"$15,300","text_number":"$126,000 Reward","percent":"0.6%","date":"2-12-2010","date_unformat":"12/25/1995","billion":".2B"},
-          {"index":3, "text":"New York","dollar":"$205,800","text_number":"2nd Place","percent":"1.5%","date":"5-12-2015","date_unformat":"February 20, 2015","billion":"1.2B"},
-          {"index":4, "text":"New Mexico","dollar":"$1,180,700","text_number":"only text","percent":"1.5%","date":"12-12-2012","date_unformat":"Jan 20, 2015","billion":"0.5B"},
-          {"index":5, "text":"California","dollar":"$188,400","text_number":"$ value","percent":"-0.4%","date":"1-1-2015","date_unformat":"3-3-2015","billion":"11B"},
-          {"index":6, "text":"Alaska","dollar":"$145,900","text_number":"Q3 2012","percent":"3.3%","date":"10-30-1915","date_unformat":"4/4/2015","billion":"9B"}
-          ]);
+    </script>
 
-        window.onload = function() {
-          console.log('page load!');
-          var elem = document.querySelector('#component');
-          // var tp = document.querySelector('#t');
-
-          //set the input
-          elem.input = input;
-
-          // tp.addEventListener('dom-change', function() {
-          //   // auto-binding template is ready.
-          //   console.log('dom changed!');
-          // });
-        }
-
-        </script>
   </body>
 </html>

--- a/demo/index.html
+++ b/demo/index.html
@@ -3,8 +3,8 @@
   <head>
     <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
     <title>lens-data-join Demo</title>
-    <script src="../webcomponentsjs/webcomponents.js"></script>
-    <link rel="import" href="lens-data-join.html">
+    <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
+    <link rel="import" href="../lens-data-join.html">
 
     <style>
       body {
@@ -55,29 +55,42 @@
 
     <script>
       // helper function to stringify objects, used below like {{outputs | json}}
-      PolymerExpressions.prototype.json = function(object) {
-        return JSON.stringify(object, undefined, 2);
-      };
+      // PolymerExpressions.prototype.json = function(object) {
+      //   return JSON.stringify(object, undefined, 2);
+      // };
     </script>
 
   </head>
   <body unresolved>
+    <lens-data-join id="component"></lens-data-join>
 
-    <template id="auto-bind-demo" is="auto-binding">
+      <script>
+        var hi = [1, 2, 3, 4400];
+      </script>
 
-      <section>
+    <template is="dom-bind">
+
+
+        <template id="t" is="dom-repeat" items="{{hi}}">
+          <div> <span>{{item}}</span> <span>{{item}}</span></div>
+        </template>
+
+    </template>
+
+<!--       <section>
         <label>Input:</label>
-        <pre id="input">{{myinput | json}}</pre>
+        <template id="inputPre">
+          <pre id="input">{{component.input}}</pre>
+        </template>
       </section>
       <section class="component">
         <label>Component:</label>
-        <lens-data-join id="component" input="{{myinput}}" output="{{myoutput}}"></lens-data-join>
       </section>
       <section>
         <label>Output:</label>
-        <pre id="output">{{myoutput | json}}</pre>
-      </section>
-      
+        <pre id="output">{{myoutput}}</pre>
+      </section> -->
+
       <script>
 
         // input data
@@ -90,10 +103,20 @@
           {"index":6, "text":"Alaska","dollar":"$145,900","text_number":"Q3 2012","percent":"3.3%","date":"10-30-1915","date_unformat":"4/4/2015","billion":"9B"}
           ]);
 
-        //set the input
-        component.input = input;
+        window.onload = function() {
+          console.log('page load!');
+          var elem = document.querySelector('#component');
+          // var tp = document.querySelector('#t');
+
+          //set the input
+          elem.input = input;
+
+          // tp.addEventListener('dom-change', function() {
+          //   // auto-binding template is ready.
+          //   console.log('dom changed!');
+          // });
+        }
 
         </script>
-      </template>
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -1,13 +1,16 @@
 <!doctype html>
-<html lang="">
-  <head>
-    <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-    <script src="../webcomponentsjs/webcomponents.js"></script>
-    <link rel="import" href="../polymer/polymer.html">
-    <link rel="import" href="../core-component-page/core-component-page.html">
-  </head>
-  <body unresolved>
-    <core-component-page></core-component-page>
-  </body>
+
+<html>
+<head>
+
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+  <script src="../webcomponentsjs/webcomponents-lite.js"></script>
+  <link rel="import" href="../iron-component-page/iron-component-page.html">
+
+</head>
+<body>
+  <iron-component-page></iron-component-page>
+</body>
 </html>

--- a/lens-data-join.html
+++ b/lens-data-join.html
@@ -15,7 +15,7 @@ Example:
 @demo
 -->
 
-<dom-module id="lens-data-join">
+<dom-module id="lens-data-join" attributes="input output">
 
   <link rel="stylesheet" href="lens-data-join.css">
 
@@ -24,7 +24,7 @@ Example:
 
       <label>Columns to join:</label>
         <template is="dom-repeat" items="{{inputKeys}}">
-          <span class="columnName" on-click="toggleSelected">{{item}}</span>
+          <span class="columnName" on-click="_toggleSelected">{{item}}</span>
         </template>
 
       <label>Join with:</label>
@@ -53,7 +53,7 @@ Example:
       input: {
         type: Array,
         value: [],
-        observer: "inputChanged"
+        observer: "_inputChanged"
       },
 
       /**
@@ -65,7 +65,9 @@ Example:
        */
       output: {
         type: Array,
-        value: []
+        value: [],
+        notify: true,
+        readOnly: true
       },
 
       /**
@@ -78,7 +80,7 @@ Example:
       selectedColumns: {
         type: Array,
         value: [],
-        observer: "selectedColumnsChanged"
+        observer: "_selectedColumnsChanged"
       },
 
       /**
@@ -91,7 +93,7 @@ Example:
       joinString: {
         type: String,
         value: ", ",
-        observer: "joinStringChanged"
+        observer: "_joinStringChanged"
       },
 
       /**
@@ -104,7 +106,7 @@ Example:
       newColumnName: {
         type: String,
         value: "new column",
-        observer: "newColumnNameChanged"
+        observer: "_newColumnNameChanged"
       },
 
       /**
@@ -118,17 +120,6 @@ Example:
         type: Boolean,
         value: true
       }
-    },
-
-    ready: function(){
-      var self = this;
-
-      console.log('attached');
-
-      self.async(function() {
-        console.log('attached async');
-        self.inputChanged();
-      })
     },
 
     _calculateOutput: function(){
@@ -147,9 +138,12 @@ Example:
         }
         self.output[i][self.newColumnName] = stringsToJoin.join(self.joinString);
       }
+
+      // fire event
+      self.fire('lens-output-changed', self.output);
     },
 
-    toggleSelected: function(e, detail){
+    _toggleSelected: function(e, detail){
       var self = this;
       var selection = e.target;
       selection.classList.toggle('selected');
@@ -160,7 +154,7 @@ Example:
     },
 
     // CHANGE OBSERVERS
-    inputChanged: function(){
+    _inputChanged: function(){
       var self = this;
 
       var input = self.input;
@@ -168,15 +162,15 @@ Example:
       self.inputKeys = self.input[0] ? Object.keys(self.input[0]) : []; // columns to choose from
       self._calculateOutput();
     },
-    selectedColumnsChanged: function(){
+    _selectedColumnsChanged: function(){
       var self = this;
       self._calculateOutput();
     },
-    joinStringChanged: function(){
+    _joinStringChanged: function(){
       var self = this;
       self._calculateOutput();
     },
-    newColumnNameChanged: function(newValue, oldValue){
+    _newColumnNameChanged: function(newValue, oldValue){
       var self = this;
       
       // Remapping triggers the change in an observer
@@ -184,7 +178,9 @@ Example:
         item[newValue] = item[oldValue];
         delete item[oldValue];
         return item;
-      })
+      });
+
+      self._calculateOutput();
     }
 
   });

--- a/lens-data-join.html
+++ b/lens-data-join.html
@@ -1,12 +1,10 @@
 <link rel="import" href="../polymer/polymer.html"> 
-<link rel="import" href="../th-theme/th-theme.html"> 
-<link rel="import" href="../core-input/core-input.html"> 
+<link rel="import" href="../iron-input/iron-input.html"> 
 
 <!--
 A data component for joining two columns together to create a new column.
 
-
-##### Example
+Example:
 
     <lens-data-join></lens-data-join>
 
@@ -14,32 +12,37 @@ A data component for joining two columns together to create a new column.
 @blurb Element providing solution to no problem in particular.
 @status alpha
 @homepage http://lenses.github.io/lens-data-join
+@demo
 -->
 
-<polymer-element name="lens-data-join" attributes="input output selectedColumns joinString newColumnName">
+<dom-module id="lens-data-join">
+
+  <link rel="stylesheet" href="lens-data-join.css">
+
   <template>
-
-    <core-style ref="theme"></core-style>
-    <link rel="stylesheet" href="lens-data-join.css">
-
     <div class="lens-container lens-data">
 
       <label>Columns to join:</label>
-        <template repeat="{{key in inputKeys}}">
-          <span class="columnName" on-click="{{toggleSelected}}">{{key}}</span>
+        <template is="dom-repeat" items="{{inputKeys}}">
+          <span class="columnName" on-click="toggleSelected">{{item}}</span>
         </template>
 
       <label>Join with:</label>
-      <input style="border: 2px solid #eee; padding: 3px; " is="core-input" committedValue="{{joinString}}" placeholder="" type="text">
+      <input style="border: 2px solid #eee; padding: 3px; " is="iron-input" bind-value="{{joinString}}" placeholder="" type="text">
 
       <label>New column name: </label>
-      <input style="border: 2px solid #eee; padding: 3px;" is="core-input" committedValue="{{newColumnName}}">
+      <input style="border: 2px solid #eee; padding: 3px;" is="iron-input" bind-value="{{newColumnName}}">
 
     </div>
 
   </template>
-  <script>
-    Polymer({
+</dom-module>
+
+<script>
+  Polymer({
+    is: 'lens-data-join',
+
+    properties: {
       /**
        *  Input data
        *
@@ -47,7 +50,11 @@ A data component for joining two columns together to create a new column.
        *  @type Array
        *  @default []
        */
-      input: [],
+      input: {
+        type: Array,
+        value: [],
+        observer: "inputChanged"
+      },
 
       /**
        *  Output data
@@ -56,7 +63,10 @@ A data component for joining two columns together to create a new column.
        *  @type Array
        *  @default []
        */
-      output: [],
+      output: {
+        type: Array,
+        value: []
+      },
 
       /**
        *  Array containing labels of the columns to be joined.
@@ -65,7 +75,11 @@ A data component for joining two columns together to create a new column.
        *  @type Array
        *  @default []
        */
-      selectedColumns: [],
+      selectedColumns: {
+        type: Array,
+        value: [],
+        observer: "selectedColumnsChanged"
+      },
 
       /**
        *  A string to place between each joined item in the new column.
@@ -74,7 +88,11 @@ A data component for joining two columns together to create a new column.
        *  @type String
        *  @default ", "
        */
-      joinString: ", ",
+      joinString: {
+        type: String,
+        value: ", ",
+        observer: "joinStringChanged"
+      },
 
       /**
        *  Name of the new column.
@@ -83,7 +101,11 @@ A data component for joining two columns together to create a new column.
        *  @type String
        *  @default ""
        */
-      newColumnName: "",
+      newColumnName: {
+        type: String,
+        value: "new column",
+        observer: "newColumnNameChanged"
+      },
 
       /**
        *  If false, the original columns will be removed from output.
@@ -92,68 +114,78 @@ A data component for joining two columns together to create a new column.
        *  @type Boolean
        *  @default true
        */
-      keepOriginalData: true,
-
-      ready: function(){
-        var self = this;
-        self.inputKeys = self.input[0] ? Object.keys(self.input[0]) : [];
-        self._calculateOutput();
-      },
-
-      _calculateOutput: function(){
-        var self = this,
-            inputLength = self.input.length;
-      
-        for (var i=0; i<self.input.length;i++){
-          var stringsToJoin = self.selectedColumns.map(function(key){
-            return self.input[i][key];
-          })
-          if(self.keepOriginalData){
-            self.output[i] = self.input[i];
-          } else {
-            self.output[i] = {};            
-          }
-          self.output[i][self.newColumnName] = stringsToJoin.join(self.joinString);
-        }
-      },
-
-      toggleSelected: function(e, detail, selection){
-        var self = this;
-        selection.classList.toggle('selected');
-
-        var selected = self.shadowRoot.querySelectorAll('.selected');
-        self.selectedColumns = [].map.call(selected, function(item) { return item.textContent});
-      },
-
-      // CHANGE OBSERVERS
-      joinStringChanged: function(){
-        var self = this;
-        self._calculateOutput();
-      },
-      inputChanged: function(){
-        var self = this;
-        self.inputKeys = self.input[0] ? Object.keys(self.input[0]) : []; // columns to choose from
-        self._calculateOutput();
-      },
-      selectedColumnsChanged: function(){
-        var self = this;
-        self._calculateOutput();
-      },
-      joinStringChanged: function(){
-        var self = this;
-        self._calculateOutput();
-      },
-      newColumnNameChanged: function(oldValue, newValue){
-        var self = this;
-        
-        // Remapping triggers the change in an observer
-        self.output = self.output.map(function(item){
-          item[newValue] = item[oldValue];
-          delete item[oldValue];
-          return item;
-        })
-
+      keepOriginalData: {
+        type: Boolean,
+        value: true
       }
-    });
-  </script>
-</polymer-element>
+    },
+
+    ready: function(){
+      var self = this;
+
+      console.log('attached');
+
+      self.async(function() {
+        console.log('attached async');
+        self.inputChanged();
+      })
+    },
+
+    _calculateOutput: function(){
+      var self = this,
+          inputLength = self.input.length;
+
+      for (var i=0; i<self.input.length;i++){
+        var stringsToJoin = self.selectedColumns.map(function(key){
+          return self.input[i][key];
+        });
+
+        if(self.keepOriginalData){
+          self.output[i] = self.input[i];
+        } else {
+          self.output[i] = {};            
+        }
+        self.output[i][self.newColumnName] = stringsToJoin.join(self.joinString);
+      }
+    },
+
+    toggleSelected: function(e, detail){
+      var self = this;
+      var selection = e.target;
+      selection.classList.toggle('selected');
+
+      var selected = self.querySelectorAll('.selected');
+
+      self.selectedColumns = [].map.call(selected, function(item) { return item.textContent});
+    },
+
+    // CHANGE OBSERVERS
+    inputChanged: function(){
+      var self = this;
+
+      var input = self.input;
+
+      self.inputKeys = self.input[0] ? Object.keys(self.input[0]) : []; // columns to choose from
+      self._calculateOutput();
+    },
+    selectedColumnsChanged: function(){
+      var self = this;
+      self._calculateOutput();
+    },
+    joinStringChanged: function(){
+      var self = this;
+      self._calculateOutput();
+    },
+    newColumnNameChanged: function(newValue, oldValue){
+      var self = this;
+      
+      // Remapping triggers the change in an observer
+      self.output = self.output.map(function(item){
+        item[newValue] = item[oldValue];
+        delete item[oldValue];
+        return item;
+      })
+    }
+
+  });
+</script>


### PR DESCRIPTION
I don't think we're ready to merge this in yet, but here's what it took to get this element ready for polymer 1.0+
- replace Polymer core- elements with Polymer iron- elements
- use "[dom-module](https://github.com/lenses/lens-data-join/compare/master...therewasaguy:polymerOne?expand=1#diff-5106ddb3c658ce03db9f5f87f181044fL19)" instead of polymer-element, and [new method of defining properties](https://github.com/lenses/lens-data-join/compare/master...therewasaguy:polymerOne?expand=1#diff-5106ddb3c658ce03db9f5f87f181044fR42)

Documentation
- replace index.html with new index.html and use iron-component-page. This automatically parses any properties and documentation. Privates should be prefixed with an underscore.
- add "@ demo" to automatically include a link to the demo

Demo
- demo.html --> demo/index.html
- template is="auto-binding" no longer works. Instead, fire a 'lens-output-changed' event on _calculateOutput, and use `document.addEventListener('lens-output-changed', callback)` to get the output when it changes.
